### PR TITLE
Upload tables of ionization and recombination rates

### DIFF
--- a/plasmapy_nei/data/.gitattributes
+++ b/plasmapy_nei/data/.gitattributes
@@ -1,0 +1,1 @@
+ionrecomb_rate.h5 filter=lfs diff=lfs merge=lfs -text

--- a/plasmapy_nei/data/ionrecomb_rate.h5
+++ b/plasmapy_nei/data/ionrecomb_rate.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d1678bb69081a3f1bf58ba1399d71b8f448edfb1c7687116e4a4a67fe5a1889
+size 57648552


### PR DESCRIPTION
This file comes from the [data directory](https://github.com/NEI-modeling/NEI/tree/830eec45a5db7b3bb7325edde0d5b18091c24ff6/nei/data/ionizrecombrates/chianti_8.07) in the [NEI-modeling/NEI](https://github.com/NEI-modeling/NEI) repository.  This data comes from Chianti version 8.07, which is about two years old.  This data file was created by Chengcai Shen, and is under the BSD 2ish clause license in that repository, which is in the `licenses` folder of this repository.