### PR TITLE
Store ionization & recombination rates file without using git large file storage

### DIFF
--- a/plasmapy_nei/data/.gitattributes
+++ b/plasmapy_nei/data/.gitattributes
@@ -1,1 +1,0 @@
-ionrecomb_rate.h5 filter=lfs diff=lfs merge=lfs -text

--- a/plasmapy_nei/data/ionrecomb_rate.h5
+++ b/plasmapy_nei/data/ionrecomb_rate.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d1678bb69081a3f1bf58ba1399d71b8f448edfb1c7687116e4a4a67fe5a1889
-size 57648552


### PR DESCRIPTION
The file `ionrecomb_rate.h5` was heretofore stored using git large file storage (LFS).  This caused some problems when people cloned the repository without having git-lfs installed, and also git-lfs charges a small but nonzero amount.  This PR takes this file and instead of getting it using git-lfs, it stores it directly in the repository.  It's a 54 MB file which is above GitHub's recommended limit of 50 MB, but it's simpler to put this directly in the repo.