### PR TITLE
Update code for use with PlasmaPy 0.6.0

### DIFF
--- a/.codemeta.json
+++ b/.codemeta.json
@@ -33,7 +33,8 @@
         "numpy >= 1.18",
         "plasmapy >= 0.6",
         "scipy >= 1.3",
-        "setuptools >= 47.0"
+        "setuptools >= 47.0",
+        "numba >= 0.47.0"
     ],
     "contributor": [
         {

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,6 +59,11 @@ jobs:
             python: 3.8
             toxenv: py38
 
+          - name: Documentation
+            os: ubuntu-latest
+            python: 3.9
+            toxenv: build_docs
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,19 +62,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-
-    - name: Create LFS file list
-      run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
-
-    - name: Restore LFS cache
-      uses: actions/cache@v2
-      id: lfs-cache
-      with:
-        path: .git/lfs
-        key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
-
-    - name: Git LFS Pull
-      run: git lfs pull
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -97,19 +84,6 @@ jobs:
     needs: tests
     steps:
     - uses: actions/checkout@master
-
-    - name: Create LFS file list
-      run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
-
-    - name: Restore LFS cache
-      uses: actions/cache@v2
-      id: lfs-cache
-      with:
-        path: .git/lfs
-        key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
-
-    - name: Git LFS Pull
-      run: git lfs pull
     - name: Get history and tags for SCM versioning to work
       run: |
         git fetch --prune --unshallow

--- a/README.md
+++ b/README.md
@@ -5,18 +5,8 @@
 [![GitHub Actions — Style linters](https://github.com/PlasmaPy/PlasmaPy/workflows/Style%20linters/badge.svg)](https://github.com/PlasmaPy/PlasmaPy/actions?query=workflow%3AStyle-linters+branch%3Amaster)
 [![Documentation Status](https://readthedocs.org/projects/plasmapy/badge/?version=latest)](http://plasmapy-nei.readthedocs.io/en/latest/?badge=latest)
 
-<!---
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](./LICENSE.md)
---->
-
-<!---[![Matrix](https://matrix.to/img/matrix-badge.svg)](https://riot.im/app/#/room/#plasmapy-nei:openastronomy.org)--->
-
 [![Matrix](https://img.shields.io/badge/Matrix-join%20chat-blueviolet?style=flat&logo=matrix)](https://app.element.io/#/room/#plasmapy-nei:openastronomy.org)
 [![astropy](http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat)](http://www.astropy.org/)
-
-<!---
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo._____.svg)](https://doi.org/10.5281/zenodo._____)
---->
 
 PlasmaPy-NEI is being developed into an affiliated package of PlasmaPy
 designed to perform non-equilibrium ionization modeling of plasma.  Use
@@ -41,7 +31,7 @@ Smithsonian Institution.
 We love contributions! PlasmaPy-NEI is open source,
 built on open source, and we'd love to have you in our community.
 
-### Imposter syndrome disclaimer 
+### Imposter syndrome disclaimer
 
 We want your help. No, really.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,9 +59,8 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://docs.scipy.org/doc/numpy", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/stable/", None),
-    "astropy": ("http://docs.astropy.org/en/stable/", None),
-    "plasmapy": ("http://docs.plasmapy.org/en/latest/", None),
+    "astropy": ("https://docs.astropy.org/en/stable/", None),
+    "plasmapy": ("https://docs.plasmapy.org/en/stable/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,28 +1,49 @@
 PlasmaPy-NEI Documentation
 ==========================
 
-The ``plasmapy_nei`` package is being developed as an affiliated package of `PlasmaPy <https://docs.plasmapy.org>`_
-designed to perform non-equilibrium ionization modelling of plasma.
-Use cases include the solar wind and coronal mass ejections.
+The ``plasmapy_nei`` package is being developed as an affiliated
+package of `PlasmaPy <https://docs.plasmapy.org>`_ designed to perform
+non-equilibrium ionization modelling of plasma.  Use cases include the
+solar wind and coronal mass ejections.
 
 Non-equilibrium ionization
 --------------------------
 
-Plasma that is kept at a constant temperature will eventually reach *ionization equilibrium*: a state where the ionization rate from an ion or neutral atom with charge :math:`Z` balances the recombination rate from an ion with charge :math:`Z+1`.
-Ionization equilibrium is a valid assumption when the changes in temperature are much longer than the characteristic time scales for ionization and recombination.
-The assumption of ionization equilibrium is built into many analysis techniques, such as differential emission measure (DEM) analyses of the solar corona and other astrophysical plasmas.  This assumption, when valid, greatly simplifies the interpretation of astrophysical spectra.
+Plasma that is kept at a constant temperature will eventually reach
+*ionization equilibrium*: a state where the ionization rate from an
+ion or neutral atom with charge :math:`Z` balances the recombination
+rate from an ion with charge :math:`Z+1`.  Ionization equilibrium is a
+valid assumption when the changes in temperature are much longer than
+the characteristic time scales for ionization and recombination.  The
+assumption of ionization equilibrium is built into many analysis
+techniques, such as differential emission measure (DEM) analyses of
+the solar corona and other astrophysical plasmas.  This assumption,
+when valid, greatly simplifies the interpretation of astrophysical
+spectra.
 
-However, the temperature and density of solar and astrophysical plasma often changes on time scales shorter than the time scale for ionization and recombination.
-As a consequence, the plasma ends up in a state of *non-equilibrium ionization (NEI)*.
-For an example in solar physics, plasma in a coronal mass ejection (CME) drops in density while propagating out of the solar corona.
-At the lowest heights, the density is high enough that ionization and recombination can keep up with the temperature changes.
-As the plasma moves away from the Sun, the density drops and the ionization and recombination time scales exceed the propagation time scales.
-Eventually the charge states freeze out and remain roughly constant for longer than it takes for the plasma to depart the heliosphere.
-Similarly, low-density plasma that is suddenly heated by a supernova remnant shock wave will be out of ionization equilibrium for some time.
-In these situations, the charge state distributions must be found by evolving the time-dependent ionization equations.
+However, the temperature and density of solar and astrophysical plasma
+often changes on time scales shorter than the time scale for
+ionization and recombination.  As a consequence, the plasma ends up in
+a state of *non-equilibrium ionization (NEI)*.  For an example in
+solar physics, plasma in a coronal mass ejection (CME) drops in
+density while propagating out of the solar corona.  At the lowest
+heights, the density is high enough that ionization and recombination
+can keep up with the temperature changes.  As the plasma moves away
+from the Sun, the density drops and the ionization and recombination
+time scales exceed the propagation time scales.  Eventually the charge
+states freeze out and remain roughly constant for longer than it takes
+for the plasma to depart the heliosphere.  Similarly, low-density
+plasma that is suddenly heated by a supernova remnant shock wave will
+be out of ionization equilibrium for some time.  In these situations,
+the charge state distributions must be found by evolving the
+time-dependent ionization equations.
 
-The ``plasmapy_nei`` package is intended to enable students and scientists to perform NEI models of laboratory, heliospheric, and astrophysical plasma.
-The early versions of this package will account for collisional ionization, radiative recombination, and dielectronic recombination.  The time advance is calculated using the eigenvalue method.
+The ``plasmapy_nei`` package is intended to enable students and
+scientists to perform NEI models of laboratory, heliospheric, and
+astrophysical plasma.  The early versions of this package will account
+for collisional ionization, radiative recombination, and dielectronic
+recombination.  The time advance is calculated using the eigenvalue
+method.
 
 .. toctree::
    :maxdepth: 2

--- a/plasmapy_nei/data/README.rst
+++ b/plasmapy_nei/data/README.rst
@@ -1,6 +1,0 @@
-Data directory
-==============
-
-This directory contains data files included with the package source
-code distribution. Note that this is intended only for relatively small files
-- large files should be externally hosted and downloaded as needed.

--- a/plasmapy_nei/eigen/__init__.py
+++ b/plasmapy_nei/eigen/__init__.py
@@ -1,3 +1,3 @@
 """Classes for accessing eigentables for ionization and recombination rates."""
 
-from .eigenclass import EigenData, eigen_data_dict
+from .eigenclass import eigen_data_dict, EigenData

--- a/plasmapy_nei/eigen/eigenclass.py
+++ b/plasmapy_nei/eigen/eigenclass.py
@@ -5,12 +5,12 @@ ionization and recombination rates.
 
 __all__ = ["EigenData", "eigen_data_dict"]
 
-import warnings
-
 import astropy.units as u
 import h5py
 import numpy as np
 import pkg_resources
+import warnings
+
 from numpy import linalg as LA
 
 try:

--- a/plasmapy_nei/eigen/tests/test_eigenclass.py
+++ b/plasmapy_nei/eigen/tests/test_eigenclass.py
@@ -1,12 +1,8 @@
 """Tests of the class to store package data."""
 
-try:
-    from plasmapy import atomic
-except ImportError:
-    from plasmapy import particles as atomic
-
 import numpy as np
 import pytest
+from plasmapy import particles
 
 from plasmapy_nei.eigen import EigenData
 
@@ -14,7 +10,7 @@ from plasmapy_nei.eigen import EigenData
 @pytest.mark.parametrize("atomic_numb", np.arange(1, 30))
 def test_instantiation(atomic_numb):
     try:
-        element_symbol = atomic.atomic_symbol(int(atomic_numb))
+        element_symbol = particles.atomic_symbol(int(atomic_numb))
         EigenData(element=element_symbol)
     except Exception as exc:
         raise Exception(
@@ -32,13 +28,13 @@ def time_advance_solver_for_testing(natom, te, ne, dt, f0, table):
     evect = table.eigenvectors(T_e_index=common_index)
     evect_invers = table.eigenvector_inverses(T_e_index=common_index)
 
-    # define the temperary diagonal matrix
-    diagona_evals = np.zeros((natom + 1, natom + 1))
+    # define the temporary diagonal matrix
+    diagonal_evals = np.zeros((natom + 1, natom + 1))
     for ii in range(0, natom + 1):
-        diagona_evals[ii, ii] = np.exp(evals[ii] * dt * ne)
+        diagonal_evals[ii, ii] = np.exp(evals[ii] * dt * ne)
 
     # matrix operation
-    matrix_1 = np.dot(diagona_evals, evect)
+    matrix_1 = np.dot(diagonal_evals, evect)
     matrix_2 = np.dot(evect_invers, matrix_1)
 
     # get ionic fraction at (time+dt)
@@ -53,19 +49,19 @@ def time_advance_solver_for_testing(natom, te, ne, dt, f0, table):
 
 
 @pytest.mark.parametrize("natom", [1, 2, 6, 7, 8])
-def test_reachequlibrium_state(natom):
+def test_reach_equilibrium_state(natom):
     """
-    Starting the random initial distribution, the charge states will reach
-    to equilibrium cases after a long time.
+    Starting from a random initial distribution, test that charge states
+    reach an equilibrium after a long time interval.
     In this test, we set the ionization and recombination rates at
     Te0=2.0e6 K and plasma density ne0=1.0e+7. A random charge states
     distribution will be finally closed to equilibrium distribution at
     2.0e6K.
     """
-    #
+
     # Initial conditions, set plasma temperature, density and dt
-    #
-    element_symbol = atomic.atomic_symbol(int(natom))
+
+    element_symbol = particles.atomic_symbol(int(natom))
     te0 = 1.0e6
     ne0 = 1.0e8
 
@@ -94,7 +90,7 @@ def test_reachequlibrium_state(natom):
     assert np.allclose(ft, table.equilibrium_state(T_e=te0))
 
 
-def test_reachequlibrium_state_multisteps(natom=8):
+def test_reach_equilibrium_state_multisteps(natom=8):
     """
     Starting the random initial distribution, the charge states will reach
     to equilibrium cases after a long time (multiple steps).

--- a/plasmapy_nei/eigen/tests/test_eigenclass.py
+++ b/plasmapy_nei/eigen/tests/test_eigenclass.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import pytest
-from plasmapy import particles
 
+from plasmapy import particles
 from plasmapy_nei.eigen import EigenData
 
 

--- a/plasmapy_nei/nei/nei.py
+++ b/plasmapy_nei/nei/nei.py
@@ -3,15 +3,15 @@
 __all__ = ["NEI", "NEIError", "SimulationResults"]
 
 
-import warnings
-from typing import Callable, Dict, List, Optional, Union
-
 import astropy.units as u
 import numpy as np
-from plasmapy.particles import IonizationStateCollection, atomic_number
-from scipy import interpolate, optimize
+import warnings
 
-from plasmapy_nei.eigen import EigenData, eigen_data_dict
+from scipy import interpolate, optimize
+from typing import Callable, Dict, List, Optional, Union
+
+from plasmapy.particles import atomic_number, IonizationStateCollection
+from plasmapy_nei.eigen import eigen_data_dict, EigenData
 
 # TODO: Allow this to keep track of velocity and position too, and
 # eventually to have density and temperature be able to be functions of

--- a/plasmapy_nei/nei/nei.py
+++ b/plasmapy_nei/nei/nei.py
@@ -477,7 +477,7 @@ class NEI:
                 inputs=inputs,
                 abundances=abundances,
                 T_e=T_e_init,
-                n=n_init,
+                n0=n_init,
                 tol=tol,
             )
 
@@ -1073,7 +1073,7 @@ class NEI:
         self._final = IonizationStateCollection(
             inputs=final_ionfracs,
             abundances=self.abundances,
-            n=np.sum(self.results.number_densities["H"][-1, :]),  # modify this later?,
+            n0=np.sum(self.results.number_densities["H"][-1, :]),  # modify this later?,
             T_e=self.results.T_e[-1],
             tol=1e-6,
         )

--- a/plasmapy_nei/nei/nei.py
+++ b/plasmapy_nei/nei/nei.py
@@ -47,7 +47,7 @@ class SimulationResults:
     Parameters
     ----------
     initial: `~plasmapy.particles.IonizationStateCollection`
-        The ``IonizationStateCollection`` instance representing the ionization
+        The `IonizationStateCollection` instance representing the ionization
         states of different elements and plasma properties as the
         initial conditions.
 

--- a/plasmapy_nei/nei/nei.py
+++ b/plasmapy_nei/nei/nei.py
@@ -483,7 +483,8 @@ class NEI:
 
             self.tol = tol
 
-            # TODO: Update IonizationStateCollection in PlasmaPy to have elements attribute
+            # TODO: Update IonizationStateCollection in PlasmaPy to have elements
+            # attribute
 
             self.elements = list(self.initial.ionic_fractions.keys())
 

--- a/plasmapy_nei/nei/nei.py
+++ b/plasmapy_nei/nei/nei.py
@@ -46,22 +46,22 @@ class SimulationResults:
 
     Parameters
     ----------
-    initial: plasmapy.atomic.IonizationStateCollection
+    initial: `~plasmapy.particles.IonizationStateCollection`
         The ``IonizationStateCollection`` instance representing the ionization
         states of different elements and plasma properties as the
         initial conditions.
 
-    n_init: astropy.units.Quantity
+    n_init: `~astropy.units.Quantity`
         The initial number density scaling factor.
 
-    T_e_init: astropy.units.Quantity
+    T_e_init: `~astropy.units.Quantity`
         The initial electron temperature.
 
-    max_steps: int
+    max_steps: `int`
         The maximum number of time steps that the simulation can take
         before stopping.
 
-    time_start: astropy.units.Quantity
+    time_start: `~astropy.units.Quantity`
         The time at the start of the simulation.
 
     """

--- a/plasmapy_nei/nei/tests/test_nei.py
+++ b/plasmapy_nei/nei/tests/test_nei.py
@@ -1,14 +1,9 @@
 """Tests for non-equilibrium ionization modeling classes."""
 
 import astropy.units as u
-
-try:
-    from plasmapy.atomic import IonizationStates, particle_symbol
-except ImportError:
-    from plasmapy.particles import IonizationStates, particle_symbol
-
 import numpy as np
 import pytest
+from plasmapy.particles import IonizationStateCollection, particle_symbol
 
 from plasmapy_nei.eigen import EigenData
 from plasmapy_nei.nei import NEI
@@ -202,7 +197,7 @@ def test_time_max(name_inputs_instance):
 
 def test_initial_type(name_inputs_instance):
     test_name, inputs, instance = name_inputs_instance
-    assert isinstance(instance.initial, IonizationStates)
+    assert isinstance(instance.initial, IonizationStateCollection)
 
 
 def test_n_input(name_inputs_instance):

--- a/plasmapy_nei/nei/tests/test_nei.py
+++ b/plasmapy_nei/nei/tests/test_nei.py
@@ -3,8 +3,8 @@
 import astropy.units as u
 import numpy as np
 import pytest
-from plasmapy.particles import IonizationStateCollection, particle_symbol
 
+from plasmapy.particles import IonizationStateCollection, particle_symbol
 from plasmapy_nei.eigen import EigenData
 from plasmapy_nei.nei import NEI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,31 @@ requires = ["setuptools",
             "numpy"]
 
 build-backend = 'setuptools.build_meta'
+
+[ tool.gilesbot ]
+  [ tool.gilesbot.pull_requests ]
+    enabled = true
+
+  [ tool.gilesbot.towncrier_changelog ]
+      enabled = true
+      changelog_skip_label = "No changelog entry needed"
+      help_url = "https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst"
+      changelog_missing = "Missing changelog entry"
+      changelog_missing_long = "This pull request needs a changelog entry file in `changelog/NUMBER.TYPE.rst`. For more information, consult https://github.com/PlasmaPy/PlasmaPy/blob/master/changelog/README.rst "
+      number_incorrect = "Incorrect changelog entry number (match PR!)"
+      number_incorrect_long = "The changelog entry's number does not match this pull request's number."
+      type_incorrect = "Incorrect changelog entry type (see list in changelog README)"
+      type_incorrect_long = "The changelog entry for this PR must have one of the types (as in NUMBER.TYPE.rst) as described in the changelog README)."
+
+[tool.isort]
+line_length = 88
+wrap_length = 80
+sections = ["FUTURE", "STDLIB", "FIRSTPARTY", "LOCALFOLDER"]
+known_first_party = ["plasmapy", ]
+default_section = "STDLIB"
+multi_line_output = 3
+use_parentheses = true
+include_trailing_comma = true
+force_alphabetical_sort_within_sections = true
+honor_noqa = true
+lines_between_types = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 astropy >= 4.0
 h5py >= 3.0
 matplotlib >= 3.1
+numba >= 0.47.0
 numpy >= 1.18
 plasmapy >= 0.6
 scipy >= 1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astropy >= 4.0
 h5py >= 3.0
 matplotlib >= 3.1
 numba >= 0.47.0
+numba_scipy
 numpy >= 1.18
 plasmapy >= 0.6
 scipy >= 1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     scipy >= 1.3
     setuptools >= 47.0
     numba >= 0.47.0
+    numba_scipy
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     plasmapy >= 0.6
     scipy >= 1.3
     setuptools >= 47.0
+    numba >= 0.47.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
There were some backward incompatible changes around PlasmaPy 0.5.0 or 0.6.0 which affect code here.  This includes `IonizationStates` being renamed to `IonizationStateCollection`, and possibly a few other changes.  